### PR TITLE
feat(articles): add Blade view‑composer for single-article and central composer loader

### DIFF
--- a/web/app/themes/maneras-theme/resources/views/single-article.blade.php
+++ b/web/app/themes/maneras-theme/resources/views/single-article.blade.php
@@ -2,49 +2,50 @@
 @extends('layouts.app')
 
 @section('content')
-  <article @php(post_class('single-article'))>
-    <header class="mb-6">
-      <h1 class="text-3xl font-bold leading-tight">
-        {{ get_the_title() }}
-      </h1>
-      <div class="flex items-center space-x-2">
-        <i data-feather="user" class="w-4 h-4"></i>
-        <span>{{ get_post_meta( get_the_ID(), 'firma_sender', true ) }}</span>
-      
-        <i data-feather="calendar" class="w-4 h-4"></i>
-        <span>{{ get_the_date('d.m.Y') }}</span>
+<article class="max-w-3xl mx-auto px-4">
+  <header class="mb-6">
+    <h1 class="text-3xl md:text-4xl font-sans font-bold leading-tight">
+      {{ $title }}
+    </h1>
 
-      </div>
-    </header>
+    <div class="flex items-center gap-2 text-sm text-text-sub mt-2">
+      <i data-feather="user"></i>
+      <span>{{ $author ?? get_the_author() }}</span>
 
-    @if (has_post_thumbnail())
-      <div class="mb-6">
-        {!! get_the_post_thumbnail(null, 'large', ['class' => 'w-full h-auto']) !!}
-      </div>
-    @endif
-
-    <div class="prose max-w-none mb-8">
-      {!! apply_filters('the_content', get_the_content()) !!}
+      <i data-feather="clock"></i>
+      <time datetime="{{ $isoDate ?? get_post_time('c', true) }}">
+        {{ $pubDate ?? get_the_date('d.m.Y') }}
+      </time>
     </div>
+  </header>
 
-    <footer class="mt-8 pt-4 border-t text-sm">
+  @if (!empty($thumb) || has_post_thumbnail())
+    <figure class="mb-6">
+      {!! $thumb ?? get_the_post_thumbnail(null, 'large', ['class' => 'w-full h-auto']) !!}
+    </figure>
+  @endif
 
-      @if ($tags = get_the_tags())
-        <div class="post-tags">
-          <ul class="tag-list flex flex-wrap list-none p-0 m-0">
-            @foreach ($tags as $tag)
-              <li>
-                <a href="{{ get_tag_link($tag->term_id) }}"
-                  class="inline-block bg-gray-100 hover:bg-gray-200 px-3 py-1 rounded">
-                  #{{ $tag->name }}
-                </a>
-              </li>
-            @endforeach
-          </ul>
-        </div>
-      @endif
-    </footer>
-  </article>
+  <div class="prose prose-invert max-w-none">
+    {!! $content ?? wp_kses_post(get_the_content()) !!}
+  </div>
+
+  <footer class="mt-8 pt-4 border-t border-border text-sm">
+    @php($tags = $tags ?? get_the_tags())
+    @if ($tags)
+      <ul class="flex flex-wrap gap-2 p-0 m-0">
+        @foreach ($tags as $tag)
+          <li>
+            <a href="{{ get_tag_link($tag->term_id) }}"
+              class="inline-block bg-surface hover:bg-border px-3 py-1 rounded">
+              #{{ $tag->name }}
+            </a>
+          </li>
+        @endforeach
+      </ul>
+    @endif
+  </footer>
+</article>
 @endsection
+
 @section('footer')
 @endsection

--- a/web/app/themes/maneras-theme/src/Helpers/helpers.php
+++ b/web/app/themes/maneras-theme/src/Helpers/helpers.php
@@ -1,4 +1,6 @@
 <?php
+// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
+// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionName
 /**
  * Helpers for the theme.
  *
@@ -20,6 +22,20 @@ use Illuminate\View\Engines\PhpEngine;
 use Illuminate\View\Engines\EngineResolver;
 use Illuminate\View\Factory;
 use Illuminate\View\FileViewFinder;
+
+if ( ! function_exists( 'render' ) ) {
+	/**
+	 * Render and display a Blade view.
+	 *
+	 * @param string $view Name of the view (without .blade.php).
+	 * @param array  $data Data to pass to the template.
+	 *
+	 * @return void
+	 */
+	function render( string $view, array $data = array() ): void {
+		echo get_blade()->make( $view, $data )->render();
+	}
+}
 
 if ( ! function_exists( 'get_blade' ) ) {
 	/**
@@ -71,8 +87,11 @@ if ( ! function_exists( 'get_blade' ) ) {
 
 			// 4) Factory
 			$factory = new Factory( $resolver, $finder, $eventDispatcher );
-			// Associate the extension
+
 			$factory->addExtension( 'blade.php', 'blade' );
+
+			\ManerasTheme\View\ViewComposers::registerAll($factory);
+			
 		}
 		return $factory;
 	}

--- a/web/app/themes/maneras-theme/src/View/Composers/SingleArticle.php
+++ b/web/app/themes/maneras-theme/src/View/Composers/SingleArticle.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ManerasTheme\View\Composers;
+
+use Illuminate\View\Factory;
+use WP_Post;
+
+/**
+ * Registers view‑composer callbacks for Jenssegers Blade.
+ */
+class SingleArticle {
+
+	public static function register( Factory $blade ): void {
+		// ← Factory
+		$blade->composer(
+			'single-article',
+			function ( $view ) {
+				/** @var WP_Post $post */
+				$post = get_post();
+
+				$view->with(
+					array(
+						'title'   => get_the_title( $post ),
+						'author'  => get_the_author_meta( 'display_name', $post->post_author ),
+						'isoDate' => get_post_time( 'c', true, $post ),
+						'pubDate' => get_the_date( 'd.m.Y', $post ),
+						'thumb'   => has_post_thumbnail( $post )
+									? get_the_post_thumbnail( $post, 'large', array( 'class' => 'w-full h-auto' ) )
+									: '',
+						'content' => apply_filters( 'the_content', $post->post_content ),
+						'tags'    => get_the_tags( $post ),
+					)
+				);
+			}
+		);
+	}
+}

--- a/web/app/themes/maneras-theme/src/View/ViewComposers.php
+++ b/web/app/themes/maneras-theme/src/View/ViewComposers.php
@@ -1,0 +1,39 @@
+<?php
+namespace ManerasTheme\View;
+
+use Illuminate\View\Factory;
+
+/**
+ * Centralises registration of all Blade view‑composers.
+ */
+final class ViewComposers {
+
+	/**
+	 * Returns an array of all view‑composers.
+	 *
+	 * @return array
+	 */
+	private static function composers(): array {
+		return array(
+			Composers\SingleArticle::class,
+			// ⬇️ añade aquí más compositores según los vayas creando
+			// Composers\ArchiveNews::class,
+			// Composers\SingleEvent::class,
+		);
+	}
+
+	/**
+	 * Registers all view‑composers.
+	 *
+	 * @param Factory $blade Blade factory instance.
+	 *
+	 * @return void
+	 */
+	public static function registerAll( Factory $blade ): void {
+		foreach ( self::composers() as $composer ) {
+			if ( method_exists( $composer, 'register' ) ) {
+				$composer::register( $blade );
+			}
+		}
+	}
+}


### PR DESCRIPTION
### What’s inside
* `SingleArticle` view‑composer injects title, author, dates, thumb, content, tags.
* `ViewComposers` loader centralises registration; helpers.php now calls `registerAll()`.
* Updated `single-article.blade.php` (already reviewed in canvas).

### How to test
1. Checkout this branch, `composer dump-autoload`.
2. Load any Article post → should render without “Undefined variable” warnings.
3. Verify tag list and thumbnail show when present.

Closes #___
