### PR TITLE
Add dark and light Twig themes

### DIFF
--- a/web/app/themes/maneras-theme-dark/composer.json
+++ b/web/app/themes/maneras-theme-dark/composer.json
@@ -1,0 +1,7 @@
+{
+  "name": "manerasdevivir/theme-dark",
+  "type": "wordpress-theme",
+  "require": {
+    "timber/timber": "^2.0"
+  }
+}

--- a/web/app/themes/maneras-theme-dark/functions.php
+++ b/web/app/themes/maneras-theme-dark/functions.php
@@ -1,0 +1,7 @@
+<?php
+use Timber\\Timber;
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+Timber::init();
+Timber::$dirname = ['templates'];

--- a/web/app/themes/maneras-theme-dark/index.php
+++ b/web/app/themes/maneras-theme-dark/index.php
@@ -1,0 +1,6 @@
+<?php
+use Timber\\Timber;
+
+$context = Timber::context();
+$context['posts'] = Timber::get_posts();
+Timber::render('index.twig', $context);

--- a/web/app/themes/maneras-theme-dark/style.css
+++ b/web/app/themes/maneras-theme-dark/style.css
@@ -1,0 +1,15 @@
+/*
+Theme Name: Maneras Dark Theme
+Author: Manerasdevivir.com
+Version: 1.0
+*/
+
+body {
+  background-color: #121212;
+  color: #e0e0e0;
+  font-family: Arial, sans-serif;
+}
+
+a {
+  color: #ff5a1e;
+}

--- a/web/app/themes/maneras-theme-dark/templates/base/layout.twig
+++ b/web/app/themes/maneras-theme-dark/templates/base/layout.twig
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html {{ site.language_attributes }}>
+<head>
+  <meta charset="{{ site.charset }}">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  {{ function('wp_head') }}
+</head>
+<body class="{{ body_class }}">
+  <header>
+    <h1><a href="{{ site.url }}">{{ site.name }}</a></h1>
+  </header>
+  <main>
+    {% block content %}{% endblock %}
+  </main>
+  <footer>
+    <p>&copy; {{ "now"|date("Y") }} {{ site.name }}</p>
+  </footer>
+  {{ function('wp_footer') }}
+</body>
+</html>

--- a/web/app/themes/maneras-theme-dark/templates/index.twig
+++ b/web/app/themes/maneras-theme-dark/templates/index.twig
@@ -1,0 +1,12 @@
+{% extends "base/layout.twig" %}
+
+{% block content %}
+  {% for post in posts %}
+    <article>
+      <h2><a href="{{ post.link }}">{{ post.title }}</a></h2>
+      <div class="entry-content">
+        {{ post.excerpt }}
+      </div>
+    </article>
+  {% endfor %}
+{% endblock %}

--- a/web/app/themes/maneras-theme-light/composer.json
+++ b/web/app/themes/maneras-theme-light/composer.json
@@ -1,0 +1,7 @@
+{
+  "name": "manerasdevivir/theme-light",
+  "type": "wordpress-theme",
+  "require": {
+    "timber/timber": "^2.0"
+  }
+}

--- a/web/app/themes/maneras-theme-light/functions.php
+++ b/web/app/themes/maneras-theme-light/functions.php
@@ -1,0 +1,7 @@
+<?php
+use Timber\\Timber;
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+Timber::init();
+Timber::$dirname = ['templates'];

--- a/web/app/themes/maneras-theme-light/index.php
+++ b/web/app/themes/maneras-theme-light/index.php
@@ -1,0 +1,6 @@
+<?php
+use Timber\\Timber;
+
+$context = Timber::context();
+$context['posts'] = Timber::get_posts();
+Timber::render('index.twig', $context);

--- a/web/app/themes/maneras-theme-light/style.css
+++ b/web/app/themes/maneras-theme-light/style.css
@@ -1,0 +1,15 @@
+/*
+Theme Name: Maneras Light Theme
+Author: Manerasdevivir.com
+Version: 1.0
+*/
+
+body {
+  background-color: #ffffff;
+  color: #222222;
+  font-family: Arial, sans-serif;
+}
+
+a {
+  color: #0077cc;
+}

--- a/web/app/themes/maneras-theme-light/templates/base/layout.twig
+++ b/web/app/themes/maneras-theme-light/templates/base/layout.twig
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html {{ site.language_attributes }}>
+<head>
+  <meta charset="{{ site.charset }}">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  {{ function('wp_head') }}
+</head>
+<body class="{{ body_class }}">
+  <header>
+    <h1><a href="{{ site.url }}">{{ site.name }}</a></h1>
+  </header>
+  <main>
+    {% block content %}{% endblock %}
+  </main>
+  <footer>
+    <p>&copy; {{ "now"|date("Y") }} {{ site.name }}</p>
+  </footer>
+  {{ function('wp_footer') }}
+</body>
+</html>

--- a/web/app/themes/maneras-theme-light/templates/index.twig
+++ b/web/app/themes/maneras-theme-light/templates/index.twig
@@ -1,0 +1,12 @@
+{% extends "base/layout.twig" %}
+
+{% block content %}
+  {% for post in posts %}
+    <article>
+      <h2><a href="{{ post.link }}">{{ post.title }}</a></h2>
+      <div class="entry-content">
+        {{ post.excerpt }}
+      </div>
+    </article>
+  {% endfor %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- scaffold modern dark theme with Twig templates and base styling
- scaffold matching light theme

## Testing
- `composer install` *(failed: wpackagist-theme/twentytwentyfive could not be downloaded)*
- `composer lint --no-ansi` *(unrecognized output, could not confirm results)*

------
https://chatgpt.com/codex/tasks/task_e_68960d53a4788321a59d1d0c4d3880d1